### PR TITLE
Feature: Toggle dark mode on logo click

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -30,10 +30,11 @@ body {
 
 header {
   display: flex;
+  flex-flow: column nowrap;
   margin-top: 10px;
-  align-items: flex-start;
+  align-items: center;
   justify-content: center;
-  gap: 20px;
+  gap: 5px;
   max-width: 80vw;
   text-align: center;
 }
@@ -149,17 +150,17 @@ img {
   font-size: 3rem;
 }
 
+/* Dark Mode Styles */ 
+.dark {
+  color: white;
+  background-color: black;
+}
+
 /* media queries */
 
 @media screen and (max-width: 600px) {
   button,
   input {
     width: 80vw;
-  }
-}
-
-@media screen and (max-width: 545px) {
-  #cloud {
-    display: none;
   }
 }

--- a/index.html
+++ b/index.html
@@ -17,8 +17,8 @@
 <body>
 
 	<header>
+		<img id="cloud" src="./img/cloudLogo-removebg-preview.png" alt="">
 		<h1>CoinCloud Price Converter</h1>
-		<img id="cloud" src="./img/cloudLogo.png" alt="">
 	</header>
 
 	<input id="amount" type="number" value="1">

--- a/js/main.js
+++ b/js/main.js
@@ -291,10 +291,20 @@ class Converter {
     document.querySelector("#currency2").value = coinOne;
     document.querySelector("#currency2").style.backgroundImage = urlOne;
   }
+
+  /* darkMode will toggle dark styles on if not present and turn off dark styles
+     if already on */
+  darkMode() {
+    const body = document.querySelector('body');
+    body.classList.toggle('dark');
+  }
 }
 
 // Create instance of Converter class
 const crypto = new Converter();
+
+// Listen for a click on the cloud logo and toggle dark mode on/off
+document.querySelector('#cloud').addEventListener('click', () => crypto.darkMode());
 
 /* 
   The event listeners perform crypto amount conversions when the Convert button 

--- a/js/main.js
+++ b/js/main.js
@@ -204,9 +204,7 @@ class Converter {
         let logo = document.createElement("img");
 
         let ticker = data[i].symbol;
-        //console.log('index: ', i);
-        //console.log(data[i].id);
-        //console.log(ticker);
+
         if (ticker === "AUD" || ticker === "CAD") {
           // Fix to get dollar image to show up for AUD and CAD in dropdown menu
           logo.src = `https://assets.coincap.io/assets/icons/usd@2x.png`;


### PR DESCRIPTION
## Changes
### HTML
Swapped the order of the **h1** and **img** elements within the **header** element so that the CoinCloud logo will be on top.

### CSS
-  Added simple dark mode styling to the **dark** class selector
-  Removed the media query for mobile devices that hid the CoinCloud logo

### JS
- Added a method called darkMode to the Converter class that toggles dark mode on/off.
-  Created an event listener that runs darkMode when the CoinCloud logo is clicked.

## Preview
[CoinCloud Price Converter](https://coinconvert.netlify.app/)


https://github.com/dwnorm2/crypto-converter/assets/131328675/7448b1fe-0565-49bd-ab8f-547c936eba16


