### PR TITLE
add dark mode for inputs/dropdowns

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -175,7 +175,6 @@ img {
 }
 
 .dropdownContent .hoverDark:hover {
-  /* background-color: rgb(61, 61, 61); */
   background-color: rgb(46, 46, 46);
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -142,6 +142,10 @@ img {
   width: 50px;
 }
 
+#cloud:hover {
+  cursor: pointer;
+}
+
 /******************************************
 /* ADDITIONAL STYLES
 /*******************************************/
@@ -150,10 +154,29 @@ img {
   font-size: 3rem;
 }
 
-/* Dark Mode Styles */ 
+/* Dark Mode Styles */
 .dark {
   color: white;
   background-color: black;
+}
+
+.inputDark {
+  background-color: rgb(32, 32, 32);
+  border: none;
+  color: white;
+}
+
+.inputContainer .dropdownInputDark {
+  border: none;
+}
+
+.optionContainer .aDark {
+  color: white;
+}
+
+.dropdownContent .hoverDark:hover {
+  /* background-color: rgb(61, 61, 61); */
+  background-color: rgb(46, 46, 46);
 }
 
 /* media queries */

--- a/js/main.js
+++ b/js/main.js
@@ -295,8 +295,24 @@ class Converter {
   /* darkMode will toggle dark styles on if not present and turn off dark styles
      if already on */
   darkMode() {
-    const body = document.querySelector('body');
-    body.classList.toggle('dark');
+    const body = document.querySelector("body");
+    const inputs = document.querySelectorAll(
+      "input, .inputContainer input, .dropdownContent, .optionContainer"
+    );
+    const dropdownInputs = document.querySelectorAll(".inputContainer input");
+    const optionLinks = document.querySelectorAll(".optionContainer a");
+    const hoverStyles = document.querySelectorAll(
+      ".dropdownContent .optionContainer"
+    );
+
+    body.classList.toggle("dark");
+
+    inputs.forEach((input) => input.classList.toggle("inputDark"));
+    dropdownInputs.forEach((input) =>
+      input.classList.toggle("dropdownInputDark")
+    );
+    optionLinks.forEach((link) => link.classList.toggle("aDark"));
+    hoverStyles.forEach((style) => style.classList.toggle("hoverDark"));
   }
 }
 
@@ -304,7 +320,9 @@ class Converter {
 const crypto = new Converter();
 
 // Listen for a click on the cloud logo and toggle dark mode on/off
-document.querySelector('#cloud').addEventListener('click', () => crypto.darkMode());
+document
+  .querySelector("#cloud")
+  .addEventListener("click", () => crypto.darkMode());
 
 /* 
   The event listeners perform crypto amount conversions when the Convert button 


### PR DESCRIPTION
### Changes:
- change cursor to pointer on cloud logo hover
- add dark mode styling to inputs/dropdowns/dropdown options

### Preview:

https://lighthearted-platypus-729d29.netlify.app/
![image](https://github.com/dwnorm2/crypto-converter/assets/112597888/b87a1ba9-5330-4bf3-924a-43eb11ed143e)


