### PR TITLE
Update: Conversion message formatting

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -33,9 +33,11 @@ class Converter {
   changeAmount() {
     this.amount = Number(document.querySelector("#amount").value);
 
-    if(this.amount < 0) {
+    if (this.amount < 0) {
       // Display error message to user if they enter a negative number
-      document.querySelector('#conversionMessage').innerText = `Invalid input: Negative numbers not allowed.`
+      document.querySelector(
+        "#conversionMessage"
+      ).innerText = `Invalid input: Negative numbers not allowed.`;
     } else {
       this.changeCoins();
       this.convert();
@@ -85,9 +87,24 @@ class Converter {
     this.coinPrice1 = await this.searchCoin(this.coin1);
     this.coinPrice2 = await this.searchCoin(this.coin2);
     this.convertedNumber = (this.amount * this.coinPrice1) / this.coinPrice2; // exchange rate
-    this.updateUI(
-      this.convertedNumber.toFixed(this.convertedNumber > 1 ? 2 : 4)
-    );
+
+    if (this.convertedNumber < 1) {
+      // for amounts less than 1
+      this.updateUI(this.convertedNumber.toFixed(10));
+    } else if (this.convertedNumber < 1000) {
+      // for amounts that don't require commas
+      this.updateUI(this.convertedNumber.toFixed(2));
+    } else {
+      /*
+      This regex uses positive lookahead to find every digit that is followed by
+      groups of three digits before a decimal point. 
+      
+      It then replaces those digits with the digit followed by a comma.
+      */
+      this.updateUI(
+        this.convertedNumber.toFixed(2).replace(/\d(?=(\d{3})+\.)/g, "$&,")
+      );
+    }
   }
 
   /*  updateUI provides an updated display of the conversion rate between the
@@ -97,7 +114,10 @@ class Converter {
       document.getElementById("conversionMessage").textContent = `${
         this.amount
       } ${this.tickers[0].toUpperCase()} = ${
-        convertedNumber > 0 ? convertedNumber : 0
+        // Checks for numbers already formatted with commas
+        convertedNumber > 0 || convertedNumber.includes(",")
+          ? convertedNumber
+          : 0
       } ${this.tickers[1].toUpperCase()}`;
     }
   }


### PR DESCRIPTION
## Changes
### main.js
Updated the `convert` method of the `Converter` class to format the numbers in the conversion message based on the size of the number.

- For amounts less than 1, 10 decimal digits will be displayed. A relatively large number of decimal digits was used for certain conversions that generate tiny fractional numbers.  Previously, such amounts would be converted to zero. For example, if I wanted to see how much Bitcoin I could purchase with $100 it would show 100 USD = 0 BTC. Now the following is displayed:

![coinsmall](https://github.com/dwnorm2/crypto-converter/assets/131328675/21ab0ee7-406c-4283-8cbb-9c4f3a1f7d40)

- The number is displayed with two decimal points for amounts greater than or equal to 1 but less than 1,000. No commas are needed.

-  For amounts greater than or equal to 1,000, a regex is used to place commas in the correct positions resulting in a number with commas and two decimal places. 

![coinlarge](https://github.com/dwnorm2/crypto-converter/assets/131328675/dbbe72f6-7179-4995-be3b-91e3bf9a3006)

Updated the `updateUI` method of the `Converter` class to display the converted number if it has already been formatted with commas.

## Concerns
### Formatting & Layout
Despite improved number formatting and increased precision, the long strings of text will cause issues with layout and style. Particularly with mobile devices, the conversion message text string will overflow causing the user to scroll to see the entire output.  Let's consider redesigning the layout or font styles to accommodate long text strings. 